### PR TITLE
Fix EHP becoming infinity when resistance attributes are missing

### DIFF
--- a/EVECompanionKit/Models/Fitting/ECKCharacterFitting.swift
+++ b/EVECompanionKit/Models/Fitting/ECKCharacterFitting.swift
@@ -420,22 +420,22 @@ public class ECKCharacterFitting: Codable, Identifiable, Hashable, ObservableObj
         }
         
         let structure: ResistanceStats = .init(hp: attributes[Self.attributeStructureHPId]?.value ?? 0,
-                                               em: attributes[Self.attributeStructureEMResistId]?.value ?? 0,
-                                               explosive: attributes[Self.attributeStructureExplosiveResistId]?.value ?? 0,
-                                               kinetic: attributes[Self.attributeStructureKineticResistId]?.value ?? 0,
-                                               thermal: attributes[Self.attributeStructureThermalResistId]?.value ?? 0)
-        
+                                               em: attributes[Self.attributeStructureEMResistId]?.value ?? 1,
+                                               explosive: attributes[Self.attributeStructureExplosiveResistId]?.value ?? 1,
+                                               kinetic: attributes[Self.attributeStructureKineticResistId]?.value ?? 1,
+                                               thermal: attributes[Self.attributeStructureThermalResistId]?.value ?? 1)
+
         let armor: ResistanceStats = .init(hp: attributes[Self.attributeArmorHPId]?.value ?? 0,
-                                           em: attributes[Self.attributeArmorEMResistId]?.value ?? 0,
-                                           explosive: attributes[Self.attributeArmorExplosiveResistId]?.value ?? 0,
-                                           kinetic: attributes[Self.attributeArmorKineticResistId]?.value ?? 0,
-                                           thermal: attributes[Self.attributeArmorThermalResistId]?.value ?? 0)
-        
+                                           em: attributes[Self.attributeArmorEMResistId]?.value ?? 1,
+                                           explosive: attributes[Self.attributeArmorExplosiveResistId]?.value ?? 1,
+                                           kinetic: attributes[Self.attributeArmorKineticResistId]?.value ?? 1,
+                                           thermal: attributes[Self.attributeArmorThermalResistId]?.value ?? 1)
+
         let shield: ResistanceStats = .init(hp: attributes[Self.attributeShieldHPId]?.value ?? 0,
-                                            em: attributes[Self.attributeShieldEMResistId]?.value ?? 0,
-                                            explosive: attributes[Self.attributeShieldExplosiveResistId]?.value ?? 0,
-                                            kinetic: attributes[Self.attributeShieldKineticResistId]?.value ?? 0,
-                                            thermal: attributes[Self.attributeShieldThermalResistId]?.value ?? 0)
+                                            em: attributes[Self.attributeShieldEMResistId]?.value ?? 1,
+                                            explosive: attributes[Self.attributeShieldExplosiveResistId]?.value ?? 1,
+                                            kinetic: attributes[Self.attributeShieldKineticResistId]?.value ?? 1,
+                                            thermal: attributes[Self.attributeShieldThermalResistId]?.value ?? 1)
         
         return .init(structure: structure, armor: armor, shield: shield)
     }


### PR DESCRIPTION
## Summary
- Resistance attributes (`shieldEMResist`, `armorThermalResist`, etc.) actually store **damage resonance** — `0.0` means full immunity, `1.0` means no resist.
- The current fallback `?? 0` was wrong: a missing resonance attribute defaults to **1.0** in the EVE SDE (no resistance), not 0.
- With `?? 0` and all four resonance attributes missing on a layer, `averageResist = 0` → `ehp = hp / 0 = .infinity`, which renders as a garbage value in the fitting view.

## Fix
Change the fallback for the 12 resonance values from `?? 0` to `?? 1` in `ECKCharacterFitting.resistances`. HP fallbacks stay `?? 0` (a missing HP attribute should remain zero).

## Test plan
- [ ] Open a fitting and verify the EHP value on shield/armor/structure is unchanged for normal ships.
- [ ] Force-clear ship attributes (e.g., with an item missing resistance entries) and confirm EHP no longer shows `inf`/garbage.
- [ ] Confirm resist bars in `FittingResistancesView` still render correctly (they use the same values via `1 - value`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)