### PR TITLE
Fix silently-empty item/implant search when text contains SQL meta-characters

### DIFF
--- a/EVECompanionKit/ECKSDEManager.swift
+++ b/EVECompanionKit/ECKSDEManager.swift
@@ -347,33 +347,41 @@ public class ECKSDEManager: @unchecked Sendable {
     
     public func getImplants(for implantSlot: Int, text: String?) -> [ECKItem] {
         do {
+            let trimmedText = text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let hasText = trimmedText.isEmpty == false
+
+            var bindings: [Binding?] = [implantSlot]
+            if hasText {
+                bindings.append("%\(trimmedText)%")
+            }
+
             let statement = try connection?.prepare("""
             SELECT
-                invTypes.typeID, 
-                typeName, 
-                description, 
-                mass, 
-                volume, 
-                capacity, 
-                radius, 
+                invTypes.typeID,
+                typeName,
+                description,
+                mass,
+                volume,
+                capacity,
+                radius,
                 iconID
             FROM
                 invTypes
                 LEFT OUTER JOIN dgmTypeAttributes ON invTypes.typeID = dgmTypeAttributes.typeID
             WHERE
                 dgmTypeAttributes.attributeID = 331
-                AND dgmTypeAttributes.valueFloat = \(implantSlot)
-                \(text != nil && text?.isEmpty == false ? "AND typeName LIKE '%\(text!)%'" : "")
-            ORDER BY 
+                AND dgmTypeAttributes.valueFloat = ?
+                \(hasText ? "AND typeName LIKE ?" : "")
+            ORDER BY
                 invTypes.typeName
-            """)
-            
+            """, bindings)
+
             guard let result = try statement?.run() else {
                 return []
             }
-            
+
             let fetchedItems = result.map({ parseItem(row: $0) })
-            
+
             return fetchedItems.map({ ECKItem(itemData: $0) })
         } catch {
             logger.error("Cannot get implants for slot \(implantSlot) with search string \(String(describing: text)): \(error)")
@@ -411,30 +419,38 @@ public class ECKSDEManager: @unchecked Sendable {
                 marketGroupSelector = ""
             }
             
+            let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let hasText = trimmedText.isEmpty == false
+
+            var bindings: [Binding?] = []
+            if hasText {
+                bindings.append("%\(trimmedText)%")
+            }
+
             let statement = try connection?.prepare("""
                 \(marketGroupSelector)
                 SELECT
                     invTypes.typeID,
-                    typeName, 
-                    description, 
-                    mass, 
-                    volume, 
-                    capacity, 
-                    radius, 
+                    typeName,
+                    description,
+                    mass,
+                    volume,
+                    capacity,
+                    radius,
                     iconID
                 FROM
                     invTypes
                     \(effectIdFilter != nil ? "INNER JOIN dgmTypeEffects ON invTypes.typeID = dgmTypeEffects.typeID" : "")
-                where 
-                    \(text.isEmpty ? "" : "typeName LIKE \"%\" || \"\(text)\" || \"%\" AND") published = 1
+                where
+                    \(hasText ? "typeName LIKE ? AND" : "") published = 1
                     \(groupIdFilter != nil ? "AND groupID = \(groupIdFilter!)" : "")
                     \(marketGroupIdFilter != nil ? "AND marketGroupID IN (SELECT id FROM marketGroups)" : "")
                     \(effectIdFilter != nil ? "AND effectID = \(effectIdFilter!)" : "")
-                ORDER BY 
+                ORDER BY
                     typeName
-                LIMIT 
+                LIMIT
                     50
-            """)
+            """, bindings)
             
             guard let result = try statement?.run() else {
                 return []


### PR DESCRIPTION
## Summary

`ECKSDEManager.getImplants(for:text:)` and `ECKSDEManager.itemSearch(...)` interpolate the user-supplied search text directly into the SQL `LIKE` clause:

```swift
"AND typeName LIKE '%\(text!)%'"
```

When `text` contains a single quote (apostrophe), it closes the SQL string literal early. SQLite refuses to prepare the statement, the call falls into the `catch` block, `logger.error(...)` runs, and the function returns `[]` — the user sees an empty search result for any query that legitimately should have matched (e.g. `O'Brien`, `Caldari 'Drake'`, or just `'`).

Solar-system search elsewhere in the file already uses `LIKE "%" || ? || "%"` correctly; the implant and item-search paths were the only remaining sites with direct string interpolation.

The same interpolation also accepts SQL meta-characters like `x' OR 1=1 --`. In a desktop app reading a read-only SDE this isn't a meaningful security concern, but parameterized bindings are the correct pattern either way.

## Fix

Switch both call sites to parameterized `LIKE ?` bindings via a `[Binding?]` array. The dynamic SQL fragment is still assembled (since the `LIKE` clause is optional), but the user-supplied string is now passed through SQLite.swift's binding array instead of being interpolated into the SQL string.

Also trims whitespace from the search input — previously a search of `"   "` would build an effectively no-op `LIKE '%   %'`.

## Reproduction

1. Open the item or implant search anywhere in the app.
2. Type any string containing a single quote — e.g. `O'Brien`, `Caldari 'Drake'`, or just `'` on its own.
3. **Expected:** items whose name contains the substring appear.
4. **Actual (before this PR):** result list is empty, even for queries that should match. Console.app shows a `logger.error(...)` line from the `catch` block (`Cannot get implants for slot ... with search string ...: ...`).

After this PR, the same search returns the expected matches.

## Test plan

- [ ] Search for an item with a normal name (e.g. `Damage Control`) — results should be unchanged.
- [ ] Search for `O'Brien` or any string containing a single quote — used to return zero results, should now match items whose name contains the substring.
- [ ] Search with empty text and only the slot/group/effect filters — confirm results still match before the change.
- [ ] Implant search with both empty and non-empty text behaves the same as before.
