### PR TITLE
Make SDE init error handling explicit instead of try?

### DIFF
--- a/EVECompanionKit/ECKSDEManager.swift
+++ b/EVECompanionKit/ECKSDEManager.swift
@@ -15,7 +15,13 @@ public class ECKSDEManager: @unchecked Sendable {
     internal var connection: Connection?
     
     private init() {
-        try? setupConnection()
+        do {
+            try setupConnection()
+        } catch {
+            // SDE may legitimately be missing on first launch; setupConnection()
+            // already logs the failure and `connection` stays nil until
+            // updateSDEFile() succeeds.
+        }
     }
     
     private func getSDEURL() throws -> URL {


### PR DESCRIPTION
## Summary
- `ECKSDEManager.init` used `try? setupConnection()`, which silently swallowed the throw after `setupConnection()` already logged it.
- The behaviour (continuing with `connection == nil` until `updateSDEFile()` runs) is actually intentional — the SDE is downloaded on first launch — but `try?` made that look like a bug and provided no signal to future readers.

## Fix
Replace `try?` with an explicit `do/catch` that documents the contract:
- `setupConnection()` still logs failures via `logger.error`.
- Init does not rethrow; the singleton stays alive with a nil connection.
- The connection is restored once `updateSDEFile()` writes the SDE and reopens.

No behaviour change — just intent made explicit.

## Test plan
- [ ] Fresh launch with no SDE on disk: app starts, logs the connection error from `setupConnection()`, SDE downloads via `ECKSDEUpdater`, queries start working.
- [ ] Normal launch with valid SDE: connection opens silently, queries unaffected.
- [ ] `Reset database` action (which calls `removeSDEFile`): app continues to run without crashing, then the next SDE update restores the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)