### PR TITLE
Adds optimal remap info sheet based on current skillqueue

### DIFF
--- a/EVECompanion/SkillPlans/DetailView/SkillPlanRemapPointCell.swift
+++ b/EVECompanion/SkillPlans/DetailView/SkillPlanRemapPointCell.swift
@@ -11,9 +11,11 @@ import EVECompanionKit
 struct SkillPlanRemapPointCell: View {
     
     private let remap: ECKSkillPlanRemap?
+    private let title: String
     
-    init(remap: ECKSkillPlanRemap?) {
+    init(remap: ECKSkillPlanRemap?, title: String = "Remap Point") {
         self.remap = remap
+        self.title = title
     }
     
     var body: some View {
@@ -24,8 +26,8 @@ struct SkillPlanRemapPointCell: View {
                     .frame(width: 40, height: 40)
                 
                 VStack(alignment: .leading) {
-                    Text("Remap Point")
-                    
+                    Text(title)
+
                     if let totalTrainingTime = remap?.totalTrainingTime,
                        totalTrainingTime > 0 {
                         Text("\(ECFormatters.remainingTime(remainingTime: totalTrainingTime))")

--- a/EVECompanion/SkillQueue/SkillQueueView.swift
+++ b/EVECompanion/SkillQueue/SkillQueueView.swift
@@ -11,7 +11,9 @@ import EVECompanionKit
 struct SkillQueueView: View {
     
     @ObservedObject var character: ECKCharacter
-    
+    @State private var showsBottomSheet = false
+    @State private var bottomSheetContentHeight: CGFloat = 300
+
     var body: some View {
         List(character.skillqueue?.currentEntries ?? []) { entry in
             NavigationLink(value: AppScreen.itemByTypeId(entry.skill.skillId)) {
@@ -50,6 +52,33 @@ struct SkillQueueView: View {
             await character.reloadSkillQueue()
         }
         .navigationTitle("Skillqueue")
+        .toolbar {
+            if character.skillqueue?.currentEntries.isEmpty == false {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showsBottomSheet = true
+                    } label: {
+                        Image("Neocom/Augmentations")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 30, height: 30)
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: $showsBottomSheet) {
+            SkillPlanRemapPointCell(remap: character.skillqueue?.calculateOptimalRemap(),
+                                    title: "Optimal Remap")
+                .padding(.horizontal, 16)
+                .padding(.vertical, 20)
+                .presentationDetents([.height(bottomSheetContentHeight)])
+                .background {
+                    GeometryReader { geo in
+                        Color.clear
+                            .onAppear { bottomSheetContentHeight = geo.size.height }
+                    }
+                }
+        }
         .overlay {
             if (character.skillqueue?.currentEntries ?? []).isEmpty && character.initialDataLoadingState == .ready {
                 ContentEmptyView(image: Image("Neocom/Skillqueue"),

--- a/EVECompanionKit/Models/ECKCharacterSkills.swift
+++ b/EVECompanionKit/Models/ECKCharacterSkills.swift
@@ -204,6 +204,19 @@ public final class ECKCharacterSkillQueue: Codable, Equatable, Hashable, Sendabl
         try container.encode(self.loadedEntries)
     }
     
+    public func calculateOptimalRemap() -> ECKSkillPlanRemap? {
+        let entries = currentEntries
+        guard entries.isEmpty == false else {
+            return nil
+        }
+
+        let skillEntries = entries.map { entry in
+            ECKSkillPlanSkillEntry(skill: ECKItem(typeId: entry.skill.skillId),
+                                   level: entry.finishLevel)
+        }
+
+        return ECKSkillPlan().calculateOptimalRemap(for: skillEntries)
+    }
 }
 
 public final class ECKCharacterSkillQueueEntry: Codable, Equatable, Identifiable, Hashable, Sendable {

--- a/EVECompanionKit/Models/SkillPlans/ECKSkillPlan.swift
+++ b/EVECompanionKit/Models/SkillPlans/ECKSkillPlan.swift
@@ -396,6 +396,18 @@ public final class ECKSkillPlan: Identifiable, Codable, ObservableObject, Hashab
         self.entries = newEntries
     }
     
+    public func calculateOptimalRemap(for entries: [ECKSkillPlanSkillEntry]) -> ECKSkillPlanRemap? {
+        guard entries.isEmpty == false else {
+            return nil
+        }
+        return optimizeChunk(entries).compactMap {
+            if case .remap(let remap) = $0 {
+                return remap
+            }
+            return nil
+        }.first
+    }
+    
     private func optimizeChunk(_ chunk: [ECKSkillPlanSkillEntry]) -> [ECKSkillPlanEntry] {
         var bestRemap = ECKSkillPlanRemap(charisma: 0, intelligence: 0, memory: 0, perception: 0, willpower: 0)
         var bestTime: TimeInterval = .greatestFiniteMagnitude


### PR DESCRIPTION
## Summary
Adds a bottom sheet to the Skill Queue view that calculates and displays the optimal attribute remap based on the character's current skill queue entries.

## Changes

**`EVECompanionKit`**
- Added `calculateOptimalRemap(for:)` public wrapper on `ECKSkillPlan` that exposes the existing `optimizeChunk()` logic without breaking its `private` encapsulation
- Added `calculateOptimalRemap()` on `ECKCharacterSkillQueue` that maps the current queue entries to skill plan entries and returns the optimal `ECKSkillPlanRemap`

**`EVECompanion`**
- Added a customizable `title` parameter to `SkillPlanRemapPointCell` (default: `"Remap Point"`) to make it reusable across contexts
- Added an augmentations toolbar button to `SkillQueueView` that opens a bottom sheet displaying the calculated optimal remap, sized dynamically to fit its content

## How it works
The optimal remap is calculated by current skill queue entries. The optimal remap sheet can be accessed by pressing the button on the SkillQueueView toolbar.

## Screenshots
<img width="301" height="655" alt="screenshot_1" src="https://github.com/user-attachments/assets/003d29bc-20b5-40bf-b1ea-e0418bc26fc2" />
<img width="301" height="655" alt="screenshot_2" src="https://github.com/user-attachments/assets/93cb19cb-c7e6-4e42-b8e2-5fe292d8ce57" />
